### PR TITLE
chore: release prep for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v0.1.0] - 2026-04-18
+## [v1.0.0] - 2026-04-19
 
 ### Added
 - Step 1: Cleanup embedding dead code and fixup decision type identification quality


### PR DESCRIPTION
## Summary
- CHANGELOG.md: bump v0.1.0 → v1.0.0, keep Unreleased section
- package.json: version 1.0.0, all fields complete
- Issue templates: bug_report.md + feature_request.md already present
- package-lock.json: fresh install to fix rollup optional dep issue

## Build & Test
- Build: clean
- Test: 335 passed

## TODO for merger
- [ ] Review CHANGELOG content
- [ ] Confirm no other v1.0 changes needed
- [ ] git tag v1.0.0 + push (manual)