### PR TITLE
fix: normalize npm bin paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Deterministic capability router and orchestration engine for local AI agents",
   "type": "module",
   "bin": {
-    "lazybrain": "./dist/bin/lazybrain.js",
-    "lb": "./dist/bin/lazybrain.js",
-    "lazybrain-mcp": "./dist/bin/mcp.js"
+    "lazybrain": "dist/bin/lazybrain.js",
+    "lb": "dist/bin/lazybrain.js",
+    "lazybrain-mcp": "dist/bin/mcp.js"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/scripts/audit-public.js
+++ b/scripts/audit-public.js
@@ -29,6 +29,14 @@ function checkVersion() {
 }
 
 function checkPack() {
+  const requiredBins = {
+    lazybrain: 'dist/bin/lazybrain.js',
+    lb: 'dist/bin/lazybrain.js',
+    'lazybrain-mcp': 'dist/bin/mcp.js',
+  };
+  for (const [name, target] of Object.entries(requiredBins)) {
+    if (pkg.bin?.[name] !== target) fail(`package.json bin.${name} must point to ${target}`);
+  }
   const raw = run('npm', ['pack', '--dry-run', '--json']);
   const entries = JSON.parse(raw);
   const files = entries[0]?.files?.map(file => file.path).sort() ?? [];


### PR DESCRIPTION
## Summary
- Normalize npm bin paths to the format npm publish auto-corrects to.
- Add public audit assertions for CLI bin mappings.

## Verification
- npm run build
- npm run lint
- npm test
- npm run audit:public
- npm publish --dry-run --tag beta --access public
- tarball install smoke with lb, lazybrain, and lazybrain-mcp
- npx gitnexus detect_changes --repo lazy-brain