### PR TITLE
docs: point beta install to GitHub prerelease

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,18 @@ You installed hundreds of AI skills, commands, plugins, and local rules. You rem
 
 ## Install
 
-Beta channel:
+Current beta prerelease:
+
+```bash
+npm install -g https://github.com/papperrollinggery/lazy-brain/releases/download/v2.0.0-beta.1/lazybrain-2.0.0.tgz
+lb quickstart
+lb "review this PR for security issues"
+```
+
+Registry beta, after npm publish:
 
 ```bash
 npm install -g lazybrain@beta
-lb quickstart
-lb "review this PR for security issues"
 ```
 
 From source:

--- a/README_CN.md
+++ b/README_CN.md
@@ -10,12 +10,18 @@
 
 ## 安装
 
-Beta channel：
+当前 beta prerelease：
+
+```bash
+npm install -g https://github.com/papperrollinggery/lazy-brain/releases/download/v2.0.0-beta.1/lazybrain-2.0.0.tgz
+lb quickstart
+lb "review this PR for security issues"
+```
+
+npm registry beta 发布后：
 
 ```bash
 npm install -g lazybrain@beta
-lb quickstart
-lb "review this PR for security issues"
 ```
 
 从源码运行：

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -2,12 +2,18 @@
 
 LazyBrain is a local-first capability router for AI agent tools. It runs on Node.js 18 or newer.
 
-## Beta Install
+## Current Beta Prerelease
+
+```bash
+npm install -g https://github.com/papperrollinggery/lazy-brain/releases/download/v2.0.0-beta.1/lazybrain-2.0.0.tgz
+lb quickstart
+lb "review this PR for security issues"
+```
+
+After npm beta is published:
 
 ```bash
 npm install -g lazybrain@beta
-lb quickstart
-lb "review this PR for security issues"
 ```
 
 If the beta package is not published yet, install from a checkout:


### PR DESCRIPTION
## Summary
- Make the current beta install command use the published GitHub prerelease tarball.
- Keep npm beta install documented as the post-registry-publish path.

## Verification
- npm run audit:public
- git diff --check
- commit hook: npm run build, npm test, npm run lint
- release tarball install smoke from GitHub URL