### PR TITLE
ci: skip npm publish when token is missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,12 @@ jobs:
 
       - name: Publish
         if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == 'false') }}
-        run: npm publish
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "::notice::NPM_TOKEN is not configured; skipping npm publish."
+            echo "Set the NPM_TOKEN repository secret, then rerun this workflow_dispatch with dry_run=false."
+            exit 0
+          fi
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Prevent Release workflow failures when prerelease tags are pushed before NPM_TOKEN is configured.
- Publish step now emits a notice and exits 0 if NODE_AUTH_TOKEN is empty.

## Cause
- v2.0.0-beta.1 tag triggered Release.
- Release attempted npm publish with empty NODE_AUTH_TOKEN.
- npm failed with ENEEDAUTH.

## Verification
- npm run audit:public
- git diff --check
- commit hook: npm run build, npm test, npm run lint